### PR TITLE
[BUGFIX] Prevent double links in menu items

### DIFF
--- a/Documentation/LanguageMenu/Index.rst
+++ b/Documentation/LanguageMenu/Index.rst
@@ -58,6 +58,7 @@ This is the corresponding code:
                noBlur = 1
                NO = 1
                NO {
+                   doNotLinkIt = 1
                    linkWrap = <li>|</li>
                    stdWrap.override = English || Deutsch || Dansk
                    stdWrap {
@@ -76,6 +77,7 @@ This is the corresponding code:
 
                ACT < .NO
                ACT.linkWrap = <li class="active">|</li>
+               
                USERDEF1 < .NO
                USERDEF1 {
                    linkWrap = <li class="text-muted">|</li>


### PR DESCRIPTION
Without the `doNotLinkIt` property the generated HTML will look like this: 

```html
<a href="/index.php?id=1&amp;L=0">
    <a href="/index.php?id=1&amp;L=0" hreflang="en-GB">
        English
    </a>
</a>
```