### PR TITLE
sys_language table is obsolete in v11 and removed in v12

### DIFF
--- a/Documentation/SettingUpLanguages/Index.rst
+++ b/Documentation/SettingUpLanguages/Index.rst
@@ -3,29 +3,15 @@
 
 .. _languages:
 
+====================
 Setting up languages
-^^^^^^^^^^^^^^^^^^^^
+====================
 
 Languages are defined in the site configuration on a per-rootpage
 basis. When creating a new page on root level via TYPO3 Backend,
 a very basic site configuration is generated on the fly.
 It prevents immediate errors due to missing configuration and can
 also serve as a starting point for all further actions.
-
-Preparation
-^^^^^^^^^^^
-
-All languages need to be set up first as :guilabel:`Website Language` record on root level.
-Use the list module and navigate to the root page. Create a new language record.
-You can set up:
-
-- Language (title): Used as label in the TYPO3 Backend
-- Select Language (dropdown): Language Key, which is used, to fetch localized data
-- Select flag icon: Icon which is used in the TYPO3 Backend to represent this language
-
-.. figure:: /Images/ManualScreenshots/SiteConfiguration/WebsiteLanguageRecord.png
-   :alt: Set up a Website Language Record
-
 
 Site Management
 ^^^^^^^^^^^^^^^
@@ -47,7 +33,7 @@ and German languages. Adding a new language is done in the
 
 Once you have defined at least one additional language,
 you have the option of translating pages and content.
-For example, the **WEB > List** module will show links
+For example, the :guilabel:`Web > List` module will show links
 for translating, provided you have translated the page
 and checked the "Localization view" at the bottom of
 the screen.
@@ -58,7 +44,7 @@ the screen.
    The Web > List view, with page translations and localize links for content elements
 
 Translated elements appears nested "under" their default language
-parent element in the **WEB > List** view.
+parent element in the :guilabel:`Web > List` view.
 
 .. figure:: /Images/ManualScreenshots/ListModule/NestedTranslations.png
    :alt: Nested translations


### PR DESCRIPTION
Tables that refer in sys_language_uid fields to ids actually use the ids from the site language setup of that page tree's site config. Therefore in v. 11 sys_language records don't need to be created anymore, in v12 they cannot be created.

releases: main, 11.5