### PR TITLE
[BREAKING] TYPO3 Frontend always rendered in UTF-8

### DIFF
--- a/Documentation/CharacterSets/Index.rst
+++ b/Documentation/CharacterSets/Index.rst
@@ -11,27 +11,6 @@ Using UTF-8 means you have a consistent data storage and can
 store any glyph from any language without thinking more about
 charsets.
 
-
-.. _character-sets-frontend:
-
-Charset in frontend (advanced)
-""""""""""""""""""""""""""""""
-
-UTF-8 is also be used in the frontend automatically and it is
-recommended to use it. However it is possible to change charset
-settings in TypoScript.
-
-:ref:`config.metaCharset <t3tsref:setup-config-metacharset>`
-defines the character set of the HTML output. If
-this is set to another value than UTF-8, all content is converted
-before output although internally processed in UTF-8. This is useful
-for special cases like Japanese websites where they e.g. use "shift-jis"
-for content delivery.
-
-If :code:`config.metaCharset` is *not* UTF-8, GET / POST data *is* automatically
-converted from :code:`config.metaCharset` to UTF-8.
-
-
 .. _character-sets-database:
 
 Database field lengths


### PR DESCRIPTION
https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.0/Breaking-97065-TYPO3FrontendAlwaysRenderedInUTF-8.html

refs https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-CoreApi/issues/1624