### PR TITLE
[TASK] #101039 - Reference method getLanguageOverlay() instead of getRecordOverlay()

### DIFF
--- a/Documentation/CoreSupport/Tca/Index.rst
+++ b/Documentation/CoreSupport/Tca/Index.rst
@@ -107,7 +107,7 @@ Another interesting point is that it will only look for a default
 language record in the current pid. This means that a
 **default language record and all its translations must be on the same page!**
 This principle is also respected by the API function
-:code:`\TYPO3\CMS\Core\Domain\Repository\PageRepository::getRecordOverlay()`
+:code:`\TYPO3\CMS\Core\Domain\Repository\PageRepository::getLanguageOverlay()`
 which fetches translations of records for the frontend display.
 
 When the "transOrigPointerField" and "languageField" are defined for a


### PR DESCRIPTION
See also: https://github.com/TYPO3/typo3/blob/12.4/typo3/sysext/core/Classes/Domain/Repository/PageRepository.php#L68-L70

Resolves: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/528
Releases: main, 12.4