### PR TITLE
There is no alternative language record

### DIFF
--- a/Documentation/PageTranslations/Index.rst
+++ b/Documentation/PageTranslations/Index.rst
@@ -6,14 +6,14 @@
 Translating pages
 =================
 
-In order to translate a page in the page tree just create a
+In order to translate a page in the page tree, create a
 copy of it with a new language relation. Use the module :guilabel:`Page` and on the top of the right side 
 :guilabel:`Language Comparison` and the lower dropdown :guilabel:`Create a new translation of this page`. 
 As soon as you choose a language of this dropdown the translation process will start with the copy of this page.
 
-The page copy will be generated in the default language with page property fields like title or description prefixed by a text similar to "[Translate to Language X:]". 
-The translated content needs to be put here, replacing the placeholder text with prefix and 
-the copied default language contents.
+The page copy will be generated in the default language with page property fields like `title` or `description` prefixed by a text similar to "[Translate to Language X:]". 
+The translated content needs to be put here, replacing the placeholder text (including the prefix and 
+the copied default language contents).
              
 Select the :guilabel:`Language Comparison` function in the upper menu bar of the
 :guilabel:`Web > Page` module. Then use the select box to create a new
@@ -36,6 +36,6 @@ The form with the fields for the translated page will then be displayed:
 Most of the fields are the same as for the page of the default language. Below
 the fields the content of the default language is shown.
 
-As long as a page has no translated copy page,
+As long as a page has no translated page record,
 its contents cannot be translated, no matter how many system languages
 have been defined.

--- a/Documentation/PageTranslations/Index.rst
+++ b/Documentation/PageTranslations/Index.rst
@@ -29,9 +29,9 @@ The form with the fields for the translated page will then be displayed:
 
     Editing the page fields for an alternative page language
 
-Most of the fields are the same as for the page of the default language. Below
+All of the fields are the same as for the page of the default language. Below
 the fields the content of the default language is shown.
 
-If a page has no translation (that means, no "alternative page language" record),
+If a page has no translation,
 its content cannot be translated, no matter how many system languages
 have been defined.

--- a/Documentation/PageTranslations/Index.rst
+++ b/Documentation/PageTranslations/Index.rst
@@ -6,10 +6,10 @@
 Translating pages
 =================
 
-When you want to translate a page in the page tree you create an
-"alternative page language" record on that page. This contains fields
-similar to that of the page record of the default language which you fill in
-with translated content.
+In order to translate a page in the page tree you create a
+copy of that record starting by its parent page. 
+It will be generated in the default language with fields prefixed by a text similar to "[Translate to Language X:]". 
+The translated content needs to be put here instead of this prefix and the original text.
 
 Select the :guilabel:`Language Comparison` function in the upper menu bar of the
 :guilabel:`Web > Page` module. Then use the select box to create a new

--- a/Documentation/PageTranslations/Index.rst
+++ b/Documentation/PageTranslations/Index.rst
@@ -6,10 +6,14 @@
 Translating pages
 =================
 
-In order to translate a page in the page tree you create a
-copy of that record starting by its parent page. 
-It will be generated in the default language with fields prefixed by a text similar to "[Translate to Language X:]". 
-The translated content needs to be put here, replacing the placeholder text with prefix and the default language contents.
+In order to translate a page in the page tree just create a
+copy of it with a new language relation. Use the module :guilabel:`Page` and on the top of the right side 
+:guilabel:`Language Comparison` and the lower dropdown :guilabel:`Create a new translation of this page`. 
+As soon as you choose a language of this dropdown the translation process will start with the copy of this page.
+
+The page copy will be generated in the default language with fields prefixed by a text similar to "[Translate to Language X:]". 
+The translated content needs to be put here, replacing the placeholder text with prefix and 
+the copied default language contents.
 
 Select the :guilabel:`Language Comparison` function in the upper menu bar of the
 :guilabel:`Web > Page` module. Then use the select box to create a new

--- a/Documentation/PageTranslations/Index.rst
+++ b/Documentation/PageTranslations/Index.rst
@@ -36,6 +36,6 @@ The form with the fields for the translated page will then be displayed:
 Most of the fields are the same as for the page of the default language. Below
 the fields the content of the default language is shown.
 
-If a page has no translation,
-its content cannot be translated, no matter how many system languages
+As long as a page has no translated copy page,
+its contents cannot be translated, no matter how many system languages
 have been defined.

--- a/Documentation/PageTranslations/Index.rst
+++ b/Documentation/PageTranslations/Index.rst
@@ -33,7 +33,7 @@ The form with the fields for the translated page will then be displayed:
 
     Editing the page fields for an alternative page language
 
-All of the fields are the same as for the page of the default language. Below
+Most of the fields are the same as for the page of the default language. Below
 the fields the content of the default language is shown.
 
 If a page has no translation,

--- a/Documentation/PageTranslations/Index.rst
+++ b/Documentation/PageTranslations/Index.rst
@@ -9,7 +9,7 @@ Translating pages
 In order to translate a page in the page tree you create a
 copy of that record starting by its parent page. 
 It will be generated in the default language with fields prefixed by a text similar to "[Translate to Language X:]". 
-The translated content needs to be put here instead of this prefix and the original text.
+The translated content needs to be put here, replacing the placeholder text with prefix and the default language contents.
 
 Select the :guilabel:`Language Comparison` function in the upper menu bar of the
 :guilabel:`Web > Page` module. Then use the select box to create a new

--- a/Documentation/PageTranslations/Index.rst
+++ b/Documentation/PageTranslations/Index.rst
@@ -11,10 +11,10 @@ copy of it with a new language relation. Use the module :guilabel:`Page` and on 
 :guilabel:`Language Comparison` and the lower dropdown :guilabel:`Create a new translation of this page`. 
 As soon as you choose a language of this dropdown the translation process will start with the copy of this page.
 
-The page copy will be generated in the default language with fields prefixed by a text similar to "[Translate to Language X:]". 
+The page copy will be generated in the default language with page property fields like title or description prefixed by a text similar to "[Translate to Language X:]". 
 The translated content needs to be put here, replacing the placeholder text with prefix and 
 the copied default language contents.
-
+             
 Select the :guilabel:`Language Comparison` function in the upper menu bar of the
 :guilabel:`Web > Page` module. Then use the select box to create a new
 translation of the page:


### PR DESCRIPTION
This has been changed. No language page record is created, but a normal page record in an alternative language.