### PR TITLE
[BUG] Fixes wrong allocation in transOrigPointerField

### DIFF
--- a/Documentation/CoreSupport/Tca/Index.rst
+++ b/Documentation/CoreSupport/Tca/Index.rst
@@ -68,7 +68,7 @@ TCA type :ref:`language <t3tca:columns-language>`.
 [transOrigPointerField]
 =======================
 
-The first field is defined by the
+The second field is defined by the
 ":ref:`transOrigPointerField <t3tca:ctrl-reference-transorigpointerfield>`"
 property and contains a reference to the record in the default language.
 


### PR DESCRIPTION
In the extended description of the 'transOrigPointerField' field, it is mentioned that it's the first field, but it is actually the second one.