### PR TITLE
[TASK] Enable Dependabot workflow updates on maintained version branches

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,4 +7,29 @@ updates:
       interval: weekly
       day: monday
     open-pull-requests-limit: 5
-    
+
+  # Maintained version branches: keep workflow action pins from drifting
+  # behind main (Dependabot only scans the default branch otherwise).
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    target-branch: "12.4"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    target-branch: "13.4"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    target-branch: "14.3"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5


### PR DESCRIPTION
## Summary

GitHub Actions version bumps currently only land on `main`, because Dependabot scans the default branch only — the maintained version branches drift. This surfaced in TYPO3-Documentation/TYPO3CMS-Guide-FrontendLocalization#136 / TYPO3-Documentation/TYPO3CMS-Guide-FrontendLocalization#137, where a backport still rendered with the old pinned `actions/checkout` v6 because the `14.3` branch never received the bump `main` got.

This PR adds per-branch `target-branch` update blocks so Dependabot keeps the workflow action pins on the maintained version branches (`12.4`, `13.4`, `14.3`) up to date directly — no backport labels or manual cherry-picks needed.

## Notes

- Scope: the version branches that still receive backports (`12.4`, `13.4`, `14.3`). `11.5` and older also still carry workflows but are left out deliberately; extend the list if you want them covered.
- Dependabot opens separate bump PRs per branch (e.g. `actions/checkout` v6 → v7 on each) starting with the next weekly run.
- The existing `main` update block is unchanged.
