### PR TITLE
Use reusable documentation testing

### DIFF
--- a/.github/workflows/test-documentation.yml
+++ b/.github/workflows/test-documentation.yml
@@ -1,17 +1,11 @@
 name: test documentation
 
-on: [ push, pull_request ]
+on:
+  push:
+  pull_request:
 
 jobs:
-  tests:
-    name: documentation
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
-
-      - name: Test if the documentation will render without warnings
-        run: |
-          mkdir -p Documentation-GENERATED-temp \
-          && docker run --rm --pull always -v $(pwd):/project \
-             ghcr.io/typo3-documentation/render-guides:latest --config=Documentation --no-progress --minimal-test
+  render:
+    uses: TYPO3-Documentation/.github/.github/workflows/reusable-test-documentation.yml@main
+    with:
+      render-flags: '--no-progress --minimal-test'


### PR DESCRIPTION
Replaced the documentation test job with a reusable workflow.

Releases: main, 14.3, 13.4